### PR TITLE
Spacy and Transformers Dependency Upgrade

### DIFF
--- a/requirements-service.txt
+++ b/requirements-service.txt
@@ -1,14 +1,14 @@
 numpy==1.16.3
 torch==1.0.1
-spacy==2.1.3
+spacy==3.0.0
 transformers==2.2.2
 Cython==0.29.10
 tqdm==4.32.2
 neuralcoref==4.0
 argparse
 scikit-learn
-bert-extractive-summarizer==0.6.1
+bert-extractive-summarizer
 Flask
 flask-cors
 nltk
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.16.3
 torch==1.0.1
-spacy==2.1.3
+spacy==3.0.0
 transformers==2.2.2
 Cython==0.29.10
 tqdm==4.32.2
@@ -8,4 +8,4 @@ neuralcoref==4.0
 argparse
 scikit-learn
 pytest
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz

--- a/summarizer/coreference_handler.py
+++ b/summarizer/coreference_handler.py
@@ -24,4 +24,4 @@ class CoreferenceHandler(SentenceHandler):
         """
         doc = self.nlp(body)._.coref_resolved
         doc = self.nlp(doc)
-        return [c.string.strip() for c in doc.sents if max_length > len(c.string.strip()) > min_length]
+        return [c.text.strip() for c in doc.sents if max_length > len(c.text.strip()) > min_length]

--- a/summarizer/sentence_handler.py
+++ b/summarizer/sentence_handler.py
@@ -28,7 +28,6 @@ class SentenceHandler(object):
 
         return to_return
 
-
     def process(self, body: str, min_length: int = 40, max_length: int = 600) -> List[str]:
         """
         Processes the content sentences.
@@ -39,7 +38,6 @@ class SentenceHandler(object):
         :return: Returns a list of sentences.
         """
         doc = self.nlp(body)
-
         return self.sentence_processor(doc, min_length, max_length)
 
     def __call__(self, body: str, min_length: int = 40, max_length: int = 600) -> List[str]:

--- a/summarizer/sentence_handler.py
+++ b/summarizer/sentence_handler.py
@@ -7,7 +7,7 @@ class SentenceHandler(object):
 
     def __init__(self, language=English):
         self.nlp = language()
-        self.nlp.add_pipe(self.nlp.create_pipe('sentencizer'))
+        self.nlp.add_pipe("sentencizer")
 
     def process(self, body: str, min_length: int = 40, max_length: int = 600) -> List[str]:
         """
@@ -19,7 +19,7 @@ class SentenceHandler(object):
         :return: Returns a list of sentences.
         """
         doc = self.nlp(body)
-        return [c.string.strip() for c in doc.sents if max_length > len(c.string.strip()) > min_length]
+        return [c.text.strip() for c in doc.sents if max_length > len(c.text.strip()) > min_length]
 
     def __call__(self, body: str, min_length: int = 40, max_length: int = 600) -> List[str]:
         return self.process(body, min_length, max_length)


### PR DESCRIPTION
Use spacy 3 model and sentencizer. This seems to be all that is needed to use Spacy 3. Thanks to https://github.com/dmmiller612/bert-extractive-summarizer/issues/95#issuecomment-775499397 pointers.

I also want to upgrade transformers version too but just going to double check it doesn't break anything.