### PR TITLE
Support for transformers 4.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.16.3
-torch==1.0.1
+torch==1.6.0
 spacy==2.1.3
-transformers==2.2.2
+transformers==4.4.0
 Cython==0.29.10
 tqdm==4.32.2
 neuralcoref==4.0

--- a/summarizer/__init__.py
+++ b/summarizer/__init__.py
@@ -1,1 +1,3 @@
 from summarizer.model_processors import Summarizer, TransformerSummarizer
+
+__all__ = ["Summarizer", "TransformerSummarizer"]

--- a/summarizer/bert_parent.py
+++ b/summarizer/bert_parent.py
@@ -3,7 +3,10 @@ from typing import List, Union
 import numpy as np
 import torch
 from numpy import ndarray
-from transformers import *
+from transformers import (AlbertModel, AlbertTokenizer, BertModel,
+                          BertTokenizer, DistilBertModel, DistilBertTokenizer,
+                          PreTrainedModel, PreTrainedTokenizer, XLMModel,
+                          XLMTokenizer, XLNetModel, XLNetTokenizer)
 
 
 class BertParent(object):
@@ -25,8 +28,8 @@ class BertParent(object):
     def __init__(
         self,
         model: str,
-        custom_model: PreTrainedModel=None,
-        custom_tokenizer: PreTrainedTokenizer=None
+        custom_model: PreTrainedModel = None,
+        custom_tokenizer: PreTrainedTokenizer = None,
     ):
         """
         :param model: Model is the string path for the bert weights. If given a keyword, the s3 path will be used.
@@ -35,12 +38,14 @@ class BertParent(object):
         """
         base_model, base_tokenizer = self.MODELS.get(model, (None, None))
 
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu")
 
         if custom_model:
             self.model = custom_model.to(self.device)
         else:
-            self.model = base_model.from_pretrained(model, output_hidden_states=True).to(self.device)
+            self.model = base_model.from_pretrained(
+                model, output_hidden_states=True).to(self.device)
 
         if custom_tokenizer:
             self.tokenizer = custom_tokenizer
@@ -60,7 +65,8 @@ class BertParent(object):
         indexed_tokens = self.tokenizer.convert_tokens_to_ids(tokenized_text)
         return torch.tensor([indexed_tokens]).to(self.device)
 
-    def _pooled_handler(self, hidden: torch.Tensor, reduce_option: str) -> torch.Tensor:
+    def _pooled_handler(self, hidden: torch.Tensor,
+                        reduce_option: str) -> torch.Tensor:
         """
         Handles torch tensor.
 
@@ -81,10 +87,9 @@ class BertParent(object):
         self,
         text: str,
         hidden: Union[List[int], int] = -2,
-        reduce_option: str ='mean',
-        hidden_concat: bool = False
+        reduce_option: str = 'mean',
+        hidden_concat: bool = False,
     ) -> torch.Tensor:
-
         """
         Extracts the embeddings for the given text.
 
@@ -127,7 +132,7 @@ class BertParent(object):
         content: List[str],
         hidden: Union[List[int], int] = -2,
         reduce_option: str = 'mean',
-        hidden_concat: bool = False
+        hidden_concat: bool = False,
     ) -> ndarray:
         """
         Create matrix from the embeddings.
@@ -148,9 +153,9 @@ class BertParent(object):
     def __call__(
         self,
         content: List[str],
-        hidden: int= -2,
+        hidden: int = -2,
         reduce_option: str = 'mean',
-        hidden_concat: bool = False
+        hidden_concat: bool = False,
     ) -> ndarray:
         """
         Create matrix from the embeddings.

--- a/summarizer/cluster_features.py
+++ b/summarizer/cluster_features.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple
+from typing import Dict, List
 
 import numpy as np
 from numpy import ndarray
@@ -17,7 +17,7 @@ class ClusterFeatures(object):
         features: ndarray,
         algorithm: str = 'kmeans',
         pca_k: int = None,
-        random_state: int = 12345
+        random_state: int = 12345,
     ):
         """
         :param features: the embedding matrix created by bert parent.
@@ -121,7 +121,8 @@ class ClusterFeatures(object):
             delta_2.append(delta_1[i] - delta_1[i-1] if i > 1 else 0.0)
 
         for j in range(len(inertias)):
-            strength = 0 if j <= 1 or j == len(inertias) -1 else delta_2[j+1] - delta_1[j+1]
+            strength = 0 if j <= 1 or j == len(
+                inertias) - 1 else delta_2[j+1] - delta_1[j+1]
 
             if strength > max_strength:
                 max_strength = strength
@@ -129,7 +130,8 @@ class ClusterFeatures(object):
 
         return k
 
-    def cluster(self, ratio: float = 0.1, num_sentences: int = None) -> List[int]:
+    def cluster(self, ratio: float = 0.1, num_sentences: int = None) -> \
+            List[int]:
         """
         Clusters sentences based on the ratio.
 
@@ -154,7 +156,8 @@ class ClusterFeatures(object):
         sorted_values = sorted(cluster_args.values())
         return sorted_values
 
-    def __call__(self, ratio: float = 0.1, num_sentences: int = None) -> List[int]:
+    def __call__(self, ratio: float = 0.1, num_sentences: int = None) -> \
+            List[int]:
         """
         Clusters sentences based on the ratio.
 

--- a/summarizer/coreference_handler.py
+++ b/summarizer/coreference_handler.py
@@ -9,7 +9,8 @@ from summarizer.sentence_handler import SentenceHandler
 
 class CoreferenceHandler(SentenceHandler):
 
-    def __init__(self, spacy_model: str = 'en_core_web_sm', greedyness: float = 0.45):
+    def __init__(self, spacy_model: str = 'en_core_web_sm',
+                 greedyness: float = 0.45):
         """
         Corefence handler. Only works with spacy < 3.0.
 
@@ -30,4 +31,6 @@ class CoreferenceHandler(SentenceHandler):
         """
         doc = self.nlp(body)._.coref_resolved
         doc = self.nlp(doc)
-        return [c.string.strip() for c in doc.sents if max_length > len(c.string.strip()) > min_length]
+        return [c.string.strip()
+                for c in doc.sents
+                if max_length > len(c.string.strip()) > min_length]

--- a/summarizer/sentence_handler.py
+++ b/summarizer/sentence_handler.py
@@ -17,12 +17,14 @@ class SentenceHandler(object):
             # Supports spacy 2.0
             self.nlp.add_pipe(self.nlp.create_pipe('sentencizer'))
             self.is_spacy_3 = False
-        except:
+        except Exception:
             # Supports spacy 3.0
             self.nlp.add_pipe("sentencizer")
             self.is_spacy_3 = True
 
-    def sentence_processor(self, doc, min_length: int = 40, max_length: int = 600) -> List[str]:
+    def sentence_processor(self, doc,
+                           min_length: int = 40,
+                           max_length: int = 600) -> List[str]:
         """
         Processes a given spacy document and turns them into sentences.
 
@@ -43,7 +45,9 @@ class SentenceHandler(object):
 
         return to_return
 
-    def process(self, body: str, min_length: int = 40, max_length: int = 600) -> List[str]:
+    def process(self, body: str,
+                min_length: int = 40,
+                max_length: int = 600) -> List[str]:
         """
         Processes the content sentences.
 
@@ -55,7 +59,9 @@ class SentenceHandler(object):
         doc = self.nlp(body)
         return self.sentence_processor(doc, min_length, max_length)
 
-    def __call__(self, body: str, min_length: int = 40, max_length: int = 600) -> List[str]:
+    def __call__(self, body: str,
+                 min_length: int = 40,
+                 max_length: int = 600) -> List[str]:
         """
         Processes the content sentences.
 


### PR DESCRIPTION
My project needs transformers v4.4.0 and bert-extractive-summarizer, however bert-extractive-summarizer==0.7.1 raises
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-52f597fbeb0b> in <module>
----> 1 from transformers import *

~\anaconda3\envs\tf\lib\site-packages\transformers\__init__.py in __getattr__(self, name)
   2306             if name == "__version__":
   2307                 return __version__
   2308             return super().__getattr__(name)
   2309 
   2310     sys.modules[__name__] = _LazyModule(__name__, _import_structure)

~\anaconda3\envs\tf\lib\site-packages\transformers\file_utils.py in __getattr__(self, name)
   1655         elif name in self._class_to_module.keys():
   1656             module = self._get_module(self._class_to_module[name])
   1657             value = getattr(module, name)
   1658         else:
   1659             raise AttributeError(f"module {self.__name__} has no attribute {name}")

~\anaconda3\envs\tf\lib\site-packages\transformers\file_utils.py in __getattr__(self, name)
   1657             value = getattr(module, name)
   1658         else:
   1659             raise AttributeError(f"module {self.__name__} has no attribute {name}")
   1660 
   1661         setattr(self, name, value)

AttributeError: module transformers.models.ibert has no attribute IBertLayer
```

when it imports `transformers` with `*`.

Replacing `*` with all used classes solves the problem and makes it possible to use transformers==4.4.0 with bert-extractive-summarizer.

- [ ] Upgraded requirements
- [ ] Fixed star imports
- [ ] Some linting fixes

