### PR TITLE
Gpu device specification support

### DIFF
--- a/summarizer/bert_parent.py
+++ b/summarizer/bert_parent.py
@@ -29,6 +29,7 @@ class BertParent(object):
         model: str,
         custom_model: PreTrainedModel = None,
         custom_tokenizer: PreTrainedTokenizer = None,
+        device_idx: int = 0,
     ):
         """
         :param model: Model is the string path for the bert weights. If given a keyword, the s3 path will be used.
@@ -37,8 +38,13 @@ class BertParent(object):
         """
         base_model, base_tokenizer = self.MODELS.get(model, (None, None))
 
-        self.device = torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cpu")
+        if torch.cuda.is_available():
+            assert (
+                isinstance(device_idx, int) and (0 <= device_idx and device_idx < torch.cuda.device_count())
+            ), f"`device_idx` must be an integer between 0 to {torch.cuda.device_count() - 1}. But got: {device_idx}"
+
+            self.device = torch.device(f"cuda:{device_idx}")
 
         if custom_model:
             self.model = custom_model.to(self.device)

--- a/summarizer/bert_parent.py
+++ b/summarizer/bert_parent.py
@@ -29,7 +29,7 @@ class BertParent(object):
         model: str,
         custom_model: PreTrainedModel = None,
         custom_tokenizer: PreTrainedTokenizer = None,
-        device_idx: int = 0,
+        gpu_id: int = 0,
     ):
         """
         :param model: Model is the string path for the bert weights. If given a keyword, the s3 path will be used.
@@ -41,10 +41,10 @@ class BertParent(object):
         self.device = torch.device("cpu")
         if torch.cuda.is_available():
             assert (
-                isinstance(device_idx, int) and (0 <= device_idx and device_idx < torch.cuda.device_count())
-            ), f"`device_idx` must be an integer between 0 to {torch.cuda.device_count() - 1}. But got: {device_idx}"
+                isinstance(gpu_id, int) and (0 <= gpu_id and gpu_id < torch.cuda.device_count())
+            ), f"`gpu_id` must be an integer between 0 to {torch.cuda.device_count() - 1}. But got: {gpu_id}"
 
-            self.device = torch.device(f"cuda:{device_idx}")
+            self.device = torch.device(f"cuda:{gpu_id}")
 
         if custom_model:
             self.model = custom_model.to(self.device)

--- a/summarizer/model_processors.py
+++ b/summarizer/model_processors.py
@@ -35,7 +35,7 @@ class ModelProcessor(object):
         sentence_handler: SentenceHandler = SentenceHandler(),
         random_state: int = 12345,
         hidden_concat: bool = False,
-        device_idx: int = 0,
+        gpu_id: int = 0,
     ):
         """
         This is the parent Bert Summarizer model. New methods should implement this class.
@@ -49,10 +49,10 @@ class ModelProcessor(object):
         CoreferenceHandler instance
         :param random_state: The random state to reproduce summarizations.
         :param hidden_concat: Whether or not to concat multiple hidden layers.
-        :param device_idx: GPU device index if CUDA is available. 
+        :param gpu_id: GPU device index if CUDA is available. 
         """
         np.random.seed(random_state)
-        self.model = BertParent(model, custom_model, custom_tokenizer, device_idx)
+        self.model = BertParent(model, custom_model, custom_tokenizer, gpu_id)
         self.hidden = hidden
         self.reduce_option = reduce_option
         self.sentence_handler = sentence_handler
@@ -318,7 +318,7 @@ class Summarizer(ModelProcessor):
         sentence_handler: SentenceHandler = SentenceHandler(),
         random_state: int = 12345,
         hidden_concat: bool = False,
-        device_idx: int = 0,
+        gpu_id: int = 0,
     ):
         """
         This is the main Bert Summarizer class.
@@ -332,11 +332,11 @@ class Summarizer(ModelProcessor):
         :param language: Which language to use for training.
         :param random_state: The random state to reproduce summarizations.
         :param hidden_concat: Whether or not to concat multiple hidden layers.
-        :param device_idx: GPU device index if CUDA is available. 
+        :param gpu_id: GPU device index if CUDA is available. 
         """
 
         super(Summarizer, self).__init__(
-            model, custom_model, custom_tokenizer, hidden, reduce_option, sentence_handler, random_state, hidden_concat, device_idx
+            model, custom_model, custom_tokenizer, hidden, reduce_option, sentence_handler, random_state, hidden_concat, gpu_id
         )
 
 
@@ -366,7 +366,7 @@ class TransformerSummarizer(ModelProcessor):
         sentence_handler: SentenceHandler = SentenceHandler(),
         random_state: int = 12345,
         hidden_concat: bool = False,
-        device_idx: int = 0,
+        gpu_id: int = 0,
     ):
         """
         :param transformer_type: The Transformer type, such as Bert, GPT2, DistilBert, etc.
@@ -377,7 +377,7 @@ class TransformerSummarizer(ModelProcessor):
         :param sentence_handler: The sentence handler class to process the raw text.
         :param random_state: The random state to use.
         :param hidden_concat: Deprecated hidden concat option.
-        :param device_idx: GPU device index if CUDA is available. 
+        :param gpu_id: GPU device index if CUDA is available. 
         """
         try:
             self.MODEL_DICT['Roberta'] = (RobertaModel, RobertaTokenizer)
@@ -397,5 +397,5 @@ class TransformerSummarizer(ModelProcessor):
         )
 
         super().__init__(
-            None, model, tokenizer, hidden, reduce_option, sentence_handler, random_state, hidden_concat, device_idx
+            None, model, tokenizer, hidden, reduce_option, sentence_handler, random_state, hidden_concat, gpu_id
         )

--- a/summarizer/model_processors.py
+++ b/summarizer/model_processors.py
@@ -34,7 +34,8 @@ class ModelProcessor(object):
         reduce_option: str = 'mean',
         sentence_handler: SentenceHandler = SentenceHandler(),
         random_state: int = 12345,
-        hidden_concat: bool = False
+        hidden_concat: bool = False,
+        device_idx: int = 0,
     ):
         """
         This is the parent Bert Summarizer model. New methods should implement this class.
@@ -48,9 +49,10 @@ class ModelProcessor(object):
         CoreferenceHandler instance
         :param random_state: The random state to reproduce summarizations.
         :param hidden_concat: Whether or not to concat multiple hidden layers.
+        :param device_idx: GPU device index if CUDA is available. 
         """
         np.random.seed(random_state)
-        self.model = BertParent(model, custom_model, custom_tokenizer)
+        self.model = BertParent(model, custom_model, custom_tokenizer, device_idx)
         self.hidden = hidden
         self.reduce_option = reduce_option
         self.sentence_handler = sentence_handler
@@ -315,7 +317,8 @@ class Summarizer(ModelProcessor):
         reduce_option: str = 'mean',
         sentence_handler: SentenceHandler = SentenceHandler(),
         random_state: int = 12345,
-        hidden_concat: bool = False
+        hidden_concat: bool = False,
+        device_idx: int = 0,
     ):
         """
         This is the main Bert Summarizer class.
@@ -329,10 +332,11 @@ class Summarizer(ModelProcessor):
         :param language: Which language to use for training.
         :param random_state: The random state to reproduce summarizations.
         :param hidden_concat: Whether or not to concat multiple hidden layers.
+        :param device_idx: GPU device index if CUDA is available. 
         """
 
         super(Summarizer, self).__init__(
-            model, custom_model, custom_tokenizer, hidden, reduce_option, sentence_handler, random_state, hidden_concat
+            model, custom_model, custom_tokenizer, hidden, reduce_option, sentence_handler, random_state, hidden_concat, device_idx
         )
 
 
@@ -362,6 +366,7 @@ class TransformerSummarizer(ModelProcessor):
         sentence_handler: SentenceHandler = SentenceHandler(),
         random_state: int = 12345,
         hidden_concat: bool = False,
+        device_idx: int = 0,
     ):
         """
         :param transformer_type: The Transformer type, such as Bert, GPT2, DistilBert, etc.
@@ -372,6 +377,7 @@ class TransformerSummarizer(ModelProcessor):
         :param sentence_handler: The sentence handler class to process the raw text.
         :param random_state: The random state to use.
         :param hidden_concat: Deprecated hidden concat option.
+        :param device_idx: GPU device index if CUDA is available. 
         """
         try:
             self.MODEL_DICT['Roberta'] = (RobertaModel, RobertaTokenizer)
@@ -391,5 +397,5 @@ class TransformerSummarizer(ModelProcessor):
         )
 
         super().__init__(
-            None, model, tokenizer, hidden, reduce_option, sentence_handler, random_state, hidden_concat
+            None, model, tokenizer, hidden, reduce_option, sentence_handler, random_state, hidden_concat, device_idx
         )

--- a/tests/test_summary_items.py
+++ b/tests/test_summary_items.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 from transformers import AlbertTokenizer, AlbertModel
 
 from summarizer import Summarizer
@@ -14,7 +15,8 @@ def custom_summarizer():
 
 @pytest.fixture()
 def summarizer():
-    return Summarizer('distilbert-base-uncased')
+    device_idx = torch.cuda.device_count() - 1  # Use the last GPU
+    return Summarizer('distilbert-base-uncased', device_idx=device_idx)
 
 
 @pytest.fixture()

--- a/tests/test_summary_items.py
+++ b/tests/test_summary_items.py
@@ -15,8 +15,8 @@ def custom_summarizer():
 
 @pytest.fixture()
 def summarizer():
-    device_idx = torch.cuda.device_count() - 1  # Use the last GPU
-    return Summarizer('distilbert-base-uncased', device_idx=device_idx)
+    gpu_id = torch.cuda.device_count() - 1  # Use the last GPU
+    return Summarizer('distilbert-base-uncased', gpu_id=gpu_id)
 
 
 @pytest.fixture()


### PR DESCRIPTION
- Added `gpu_id` and its argument description to `BertParent`, `ModelProcessor`, `Summarizer`, and `TransformerSummarizer`.
- Added an assertion in `BertParent` to check whether the specified `gpu_id` is valid.
- Modified `test_summary_items.py` to test the new feature and tested.
- `gpu_id`'s default is 0 and only be used when CUDA is available.