### PR TITLE
Process only unique text

### DIFF
--- a/summarizer/text_processors/sentence_handler.py
+++ b/summarizer/text_processors/sentence_handler.py
@@ -39,4 +39,8 @@ class SentenceHandler(SentenceABC):
         :return: Returns a list of sentences.
         """
         doc = self.nlp(body)
-        return self.sentence_processor(doc, min_length, max_length)
+        
+        sentences = self.sentence_processor(doc, min_length, max_length)
+        unique_sentences = list(dict.fromkeys([s.strip() for s in sentences]))
+        
+        return unique_sentences


### PR DESCRIPTION
Make sure that only unique text is passed to the clustering algorithm. This helps to avoid `ConvergenceWarning` and makes sure that the summary does not repeat sentences.